### PR TITLE
Return errors instead of log.Fataln. Add documentation to all exported functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,19 +7,27 @@ Go Package to get information regarding the novel corona virus provided by Johns
 Full Documentation can be found [here](https://ahmednafies.github.io/go-covid/)
 
 ## How to install
-
     go get -u github.com/ahmednafies/go-covid/covid
 
 ## How to use
 
 ### Get All Data
 
-    data := covid.GetData()
+
+    data, err := covid.GetData()
+    if err != nil {
+        // Handle error here
+    }
     fmt.Println(data)
+
 
 ### Get Status By Country Name
 
-    data := covid.GetCountryByName("italy")
+    data, err := covid.GetCountryByName("italy")
+    if err != nil {
+        // Handle error here
+    }
+
     fmt.Println(data.Attrs.Id)
     fmt.Println(data.Attrs.Country)
     fmt.Println(data.Attrs.LastUpdate)
@@ -43,7 +51,10 @@ Full Documentation can be found [here](https://ahmednafies.github.io/go-covid/)
 
 ### List Countries
 
-    covid.ListCountries()
+    list, err := covid.ListCountries()
+    if err != nil {
+        // Handle error here
+    }
 
 #### Result
 
@@ -61,20 +72,20 @@ Full Documentation can be found [here](https://ahmednafies.github.io/go-covid/)
 
 ### Get Status by Country ID
 
-    data := covid.GetCountryById(113)
+    data, err := covid.GetCountryById(113)
 
 ### Get Total Active Cases
 
-    active := covid.GetTotalActive()
+    active, err := covid.GetTotalActive()
 
 ### Get Total Confirmed Cases
 
-    confirmed := covid.GetTotalConfirmed()
+    confirmed, err := covid.GetTotalConfirmed()
 
 ### Get Total Recovered Cases
 
-    recovered := covid.GetTotalRecovered()
+    recovered, err := covid.GetTotalRecovered()
 
 ### Get Total Deaths
 
-    deaths := covid.GetTotalDeaths()
+    deaths, err := covid.GetTotalDeaths()

--- a/covid/covid.go
+++ b/covid/covid.go
@@ -97,6 +97,7 @@ func getTotalUrl(field string) string {
 	return _url.String()
 }
 
+// GetData returns the entire data of every country
 func GetData() ([]Case, error) {
 	resp, err := http.Get(getAllUrl())
 	if err != nil {
@@ -110,7 +111,7 @@ func GetData() ([]Case, error) {
 	defer resp.Body.Close()
 
 	var res Response
-	json.Unmarshal(body, &res)
+	err = json.Unmarshal(body, &res)
 	if err != nil {
 		return nil, err
 	}
@@ -118,6 +119,8 @@ func GetData() ([]Case, error) {
 	return res.Values, nil
 }
 
+// GetCountryById returns the statistics/data of
+// a particular country specified by id
 func GetCountryById(id int) (Case, error) {
 	resp, err := http.Get(getCountryUrl(id))
 	if err != nil {
@@ -139,6 +142,10 @@ func GetCountryById(id int) (Case, error) {
 	return res.Values[0], nil
 }
 
+// ListCountries returns a "list" or slice of countries, that shows the id and name
+// of a country as understood by this api. This method is handy when you want
+// the ID or name of a country to use with methods GetCountryById and GetCountryByName
+// respectively
 func ListCountries() ([]Country, error) {
 	resp, err := http.Get(getAllUrl())
 	if err != nil {
@@ -174,6 +181,8 @@ func getCountryId(name string) (int, error) {
 	return -1, errors.New("Wrong country name")
 }
 
+// GetCountryByName returns the statistics/data of
+// a particular country as supplied by name
 func GetCountryByName(name string) (Case, error) {
 	id, err := getCountryId(name)
 	if err != nil {
@@ -221,6 +230,7 @@ func getTotal(field string) (Stats, error) {
 	return res.Values[0], nil
 }
 
+// GetTotalActive returns the total number of active cases globally
 func GetTotalActive() (int, error) {
 	data, err := getTotal("Active")
 	if err != nil {
@@ -229,6 +239,8 @@ func GetTotalActive() (int, error) {
 	return data.Attrs.Value, nil
 }
 
+
+// GetTotalConfirmed returns the total number of confirmed cases globally
 func GetTotalConfirmed() (int, error) {
 	data, err := getTotal("Confirmed")
 	if err != nil {
@@ -236,6 +248,8 @@ func GetTotalConfirmed() (int, error) {
 	}
 	return data.Attrs.Value, err
 }
+
+// GetTotalRecovered returns the total number of recovered cases globally
 func GetTotalRecovered() (int, error) {
 	data, err := getTotal("Recovered")
 	if err != nil {
@@ -243,6 +257,8 @@ func GetTotalRecovered() (int, error) {
 	}
 	return data.Attrs.Value, nil
 }
+
+// GetTotalDeaths returns the total number of deaths recorded globally
 func GetTotalDeaths() (int, error) {
 	data, err := getTotal("Deaths")
 	if err != nil {

--- a/covid/covid.go
+++ b/covid/covid.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -98,71 +97,75 @@ func getTotalUrl(field string) string {
 	return _url.String()
 }
 
-func GetData() []Case {
+func GetData() ([]Case, error) {
 	resp, err := http.Get(getAllUrl())
 	if err != nil {
-		log.Fatalln(err)
+		return nil, err
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		log.Fatalln(err)
+		return nil, err
 	}
 	defer resp.Body.Close()
 
 	var res Response
 	json.Unmarshal(body, &res)
 	if err != nil {
-		log.Fatalln(err)
+		return nil, err
 	}
 
-	return res.Values
+	return res.Values, nil
 }
 
-func GetCountryById(id int) Case {
+func GetCountryById(id int) (Case, error) {
 	resp, err := http.Get(getCountryUrl(id))
 	if err != nil {
-		log.Fatalln(err)
+		return Case{}, err
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		log.Fatalln(err)
+		return Case{}, err
 	}
 	defer resp.Body.Close()
 
 	var res Response
-	json.Unmarshal(body, &res)
+	err = json.Unmarshal(body, &res)
 	if err != nil {
-		log.Fatalln(err)
+		return Case{}, err
 	}
 
-	return res.Values[0]
+	return res.Values[0], nil
 }
 
-func ListCountries() []Country {
+func ListCountries() ([]Country, error) {
 	resp, err := http.Get(getAllUrl())
 	if err != nil {
-		log.Fatalln(err)
+		return nil, err
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		log.Fatalln(err)
+		return nil, err
 	}
 	defer resp.Body.Close()
 
 	var res CountryResponse
-	json.Unmarshal(body, &res)
+	err = json.Unmarshal(body, &res)
 	if err != nil {
-		log.Fatalln(err)
+		return nil, err
 	}
 
-	return res.Values
+	return res.Values, nil
 }
 
 func getCountryId(name string) (int, error) {
-	countries := ListCountries()
+	countries, err := ListCountries()
+	if err != nil {
+		return -1, err
+	}
+
 	for _, country := range countries {
 		if strings.ToLower(country.Attrs.Name) == strings.ToLower(name) {
 			return country.Attrs.Id, nil
@@ -171,67 +174,79 @@ func getCountryId(name string) (int, error) {
 	return -1, errors.New("Wrong country name")
 }
 
-func GetCountryByName(name string) Case {
+func GetCountryByName(name string) (Case, error) {
 	id, err := getCountryId(name)
 	if err != nil {
-		log.Fatalln(err)
+		return Case{}, err
 	}
 
 	resp, err := http.Get(getCountryUrl(id))
 	if err != nil {
-		log.Fatalln(err)
+		return Case{}, err
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		log.Fatalln(err)
+		return Case{}, err
 	}
 	defer resp.Body.Close()
 
 	var res Response
-	json.Unmarshal(body, &res)
+	err = json.Unmarshal(body, &res)
 	if err != nil {
-		log.Fatalln(err)
+		return Case{}, err
 	}
 
-	return res.Values[0]
+	return res.Values[0], nil
 }
 
-func getTotal(field string) Stats {
+func getTotal(field string) (Stats, error) {
 	resp, err := http.Get(getTotalUrl(field))
 	if err != nil {
-		log.Fatalln(err)
+		return Stats{}, err
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		log.Fatalln(err)
+		return Stats{}, err
 	}
 	defer resp.Body.Close()
 
 	var res StatsResponse
-	json.Unmarshal(body, &res)
+	err = json.Unmarshal(body, &res)
 	if err != nil {
-		log.Fatalln(err)
+		return Stats{}, err
 	}
 
-	return res.Values[0]
+	return res.Values[0], nil
 }
 
-func GetTotalActive() int {
-	data := getTotal("Active")
-	return data.Attrs.Value
+func GetTotalActive() (int, error) {
+	data, err := getTotal("Active")
+	if err != nil {
+		return -1, err
+	}
+	return data.Attrs.Value, nil
 }
 
-func GetTotalConfirmed() int {
-	data := getTotal("Confirmed")
-	return data.Attrs.Value
+func GetTotalConfirmed() (int, error) {
+	data, err := getTotal("Confirmed")
+	if err != nil {
+		return -1, err
+	}
+	return data.Attrs.Value, err
 }
-func GetTotalRecovered() int {
-	data := getTotal("Recovered")
-	return data.Attrs.Value
+func GetTotalRecovered() (int, error) {
+	data, err := getTotal("Recovered")
+	if err != nil {
+		return -1, err
+	}
+	return data.Attrs.Value, nil
 }
-func GetTotalDeaths() int {
-	data := getTotal("Deaths")
-	return data.Attrs.Value
+func GetTotalDeaths() (int, error) {
+	data, err := getTotal("Deaths")
+	if err != nil {
+		return -1, err
+	}
+	return data.Attrs.Value, nil
 }


### PR DESCRIPTION
For people using this package this will probably be a breaking change. I would suggest you version this to make it easy for people to chose which version to use

The functions in the package now return errors instead of log.Fatalln
log.Fatalln will cause the programs that use this package to stop. Rather the errors are returned and it is now up to the user of this package to handle the errors.

Also the exported functions in the package have all been documented to make it easy for people using this package to understand what each function does.

